### PR TITLE
:ambulance: Fix import base in migrations file.

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -5,7 +5,7 @@ import alembic_postgresql_enum  # type: ignore
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from src.api.db.models import Base
+from src.db.models import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
- Fixed `Base` schema model in `env.py` Alembic config file.